### PR TITLE
Add option to only generate hashtags if a specific condition is met

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ class Picture < ActiveRecord::Base
 end
 ```
 
+If you only want hashtags created based on conditions,
+you can create a guard with `hashtag_if`:
+
+```ruby
+class Post < ActiveRecord::Base
+  include SimpleHashtag::Hashtaggable
+
+  hashtag_if ->(post) { post.body =~ /ruby/ }
+end
+
+# or...
+
+class Post < ActiveRecord::Base
+  include SimpleHashtag::Hashtaggable
+
+  hashtag_if :about_ruby?
+
+  def about_ruby?
+    body =~ /ruby/
+  end
+end
+```
+
+
 From here on, if your text contains a hashtag, say _#RubyRocks_,
 _Simple Hasthag_ will find it, store it in a table and retreive it and its associated object if asked.
 Helpers are also available to create a link when displaying the text.


### PR DESCRIPTION
> Some things are better left unsaid
> Some strings are better left undone
> Some hearts are better left unbroken
> Some social media is better left unhashtagged

This PR adds the option to create a guard (either a lambda or a method) that's checked before creating hashtags - the example given in the `README` and specs is pretty basic, but in practice this works well for more advanced checks on relationships and permissions and such.
