### PR TITLE
Don't query for hashtags when its not change

### DIFF
--- a/lib/simple_hashtag/hashtaggable.rb
+++ b/lib/simple_hashtag/hashtaggable.rb
@@ -15,6 +15,7 @@ module SimpleHashtag
       end
 
       def update_hashtags
+        return unless self.changed.include?(self.class.hashtaggable_attribute_name.to_s) || self.destroyed?
         self.hashtags = parsed_hashtags
       end
 


### PR DESCRIPTION
When hashtaggable_attribute_name is not changed that time don't do any query for hashtag.
